### PR TITLE
fix load error when no save file is present - issue #2

### DIFF
--- a/script.js
+++ b/script.js
@@ -181,7 +181,9 @@ function loadGridFromLocalStorage() {
   });
 }
 
-const loadGrid = debounce(() => loadGridFromLocalStorage());
+const loadGrid = debounce(() => {
+  if (localStorage.getItem('pixel')) loadGridFromLocalStorage();
+});
 
 /* Event Handlers */
 


### PR DESCRIPTION
Changes the debounce call to loadGridFromLocalStorage to only run if there's something stored there